### PR TITLE
commented out the Jackson dependencies as they are duplicates. Added …

### DIFF
--- a/bus-api/.gitignore
+++ b/bus-api/.gitignore
@@ -32,3 +32,4 @@ build/
 ### VS Code ###
 .vscode/
 log/
+src/main/java/sg/edu/ntu/bus_api/service/ApiKey.java

--- a/bus-api/pom.xml
+++ b/bus-api/pom.xml
@@ -32,7 +32,7 @@
 	</properties>
 	<dependencies>
 		<!-- Start Jackson Object Mapper-->
-		<dependency>
+		<!-- <dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 		</dependency>
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-		</dependency>
+		</dependency> -->
 		<!-- End Jackson Object Mapper-->
 
 		<dependency>


### PR DESCRIPTION
…ApiKey.java in the .gitignore so that we do not have to always remove API key in our local repo each time we just want to git push to our own forked repo. Git will just not track any future edits to ApiKey.java from now on, the original ApiKey.java version will still remain in the repo