### PR TITLE
added index.html to show something else than Whitelabel error page w…

### DIFF
--- a/bus-api/src/main/resources/static/index.html
+++ b/bus-api/src/main/resources/static/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body {
+        background-color: black;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        margin: 0;
+        flex-direction: column;
+      }
+      h1 {
+        color: white;
+        font-family: Arial;
+        text-align: center;
+      }
+      p {
+        color: red;
+        font-family: Arial;
+        font-size: 200%;
+        text-align: center;
+      }
+    </style>
+    <title>Group 5 SE-8 Springboot App Placeholder Page</title>
+  </head>
+
+  <body>
+    <h1>🚨 Group 5 SE-8 Module 3 Project 🚨</h1>
+    <p>Please access the API endpoints directly. 🚌</p>
+  </body>
+</html>


### PR DESCRIPTION
…hen access localhost:8080. Whitelabel error page is shown when Springboot app has no explicit mapping for /error, so we see that as a fallback