### PR TITLE
Jimmy/remove bus stop validation for lat long

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SE8-Group5-API
 
+This is a backup copy of main branch version 0.3a
+
 ## Keeping Datamall API secret
 
 ### Step 1:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SE8-Group5-API
 
-This is a backup copy of main branch version 0.3a
+Version 4.0.0
+- Removed bus stop @DecimalMax @DecimalMin for Latitude and Longitude causes error during the pull of BusStops from LTA Datamall because there's bus stops in Malaysia but my Latitude Longitude min and max range settings to only Singapore land block those bus stops from getting pulled from LTA Datamall
 
 ## Keeping Datamall API secret
 

--- a/bus-api/src/main/java/sg/edu/ntu/bus_api/entity/BusStop.java
+++ b/bus-api/src/main/java/sg/edu/ntu/bus_api/entity/BusStop.java
@@ -6,8 +6,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -46,12 +44,8 @@ public class BusStop {
   private String description;
 
   @Column(name="Latitude")
-  @DecimalMin(value = "1.2366", message = "Latitude must be greater than or equal to 1.2366 to still be in Singapore")
-  @DecimalMax(value = "1.4719", message = "Latitude must be less than or equal to 1.4719 to still be in Singapore")
   private Double latitude;
 
   @Column(name="Longitude")
-  @DecimalMin(value = "103.6058", message = "Longitude must be greater than or equal to 103.6058 to still be in Singapore")
-  @DecimalMax(value = "104.0473", message = "Longitude must be less than or equal to 104.0473 to still be in Singapore")
   private Double longitude;
 }


### PR DESCRIPTION
Version 4.0.0
- Removed bus stop @DecimalMax @DecimalMin for Latitude and Longitude causes error during the pull of BusStops from LTA Datamall because there's bus stops in Malaysia but my Latitude Longitude min and max range settings to only Singapore land block those bus stops from getting pulled from LTA Datamall